### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ github "gservera/ScheduleKit" "master"
 
 Run `carthage update` on your project's directory to build the framework and drag the built `ScheduleKit.framework` into your Xcode project.
  
-##Ideas for the future
+## Ideas for the future
  
 * Ability to create an event by clicking and dragging on a region of the view (thus, setting the corresponding start and end date values), as suggested by @ronnyek
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
